### PR TITLE
cryptochat 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Encrypted (see ```encryption.js```, currently uses the [crypto](https://nodejs.org/api/crypto.html) module's **AES-256-CTR**) P2P chat over ICMP using ```ping``` requests.
 
-Uses the awesome [raw-socket](http://npmjs.org/package/raw-socket) for ICMP monitoring.
+Uses [raw-socket](http://npmjs.org/package/raw-socket) for ICMP handling.
 
 ### Install and usage
 
@@ -34,10 +34,8 @@ Three variants of cryptochat are available depending on your use case:
 Because it relies on ```stdin``` for input, it is possible to use pipes to send data:
 
 ```bash
-cat cryptochat.js | sudo cryptochat <ip> <encryption_key>
+cat cryptochat.js | sudo cryptochat client <ip> <encryption_key>
 ```
-
-That is quite awesome.
 
 ### [ICMP Echo request](https://en.wikipedia.org/wiki/Ping_(networking_utility)) format
 
@@ -50,7 +48,7 @@ That is quite awesome.
   <tr>
     <td>type = <code>0x08</code></td>
     <td>code = <code>0x00</code></td>
-    <td>header checksum</td>
+    <td>checksum</td>
   </tr>
   <tr>
     <td colspan="2">identifier</td>
@@ -64,37 +62,20 @@ That is quite awesome.
 The message data is attached as the ICMP payload.
 
 ### Message
-Messages are piped from ```stdin``` and split into payload packages, which are encrypted separately and sent as ICMP Echo requests.
-
-<table>
-  <tr>
-    <td><b>bits 0-15</b></td>
-    <td><b>bits 16-31</b></td>
-  </tr>
-  <tr>
-    <td>identifier = <code>0x6363</code></td>
-    <td>message length</td>
-  </tr>
-  <tr>
-    <td colspan="3">message</td>
-  </tr>
-</table>
+Messages are piped from ```stdin``` and split into payload packages, which are encrypted and sent as ICMP Echo requests. The payload size per request is currently set to 32 bytes. The first byte is the length of the message and the rest is the message itself.
 
 An "end" request is sent in order for the receiver to know when a message is completed. The end request has the following format:
 
 <table>
   <tr>
-    <td><b>bits 0-15</b></td>
-    <td><b>bits 16-31</b></td>
+    <td><b>length</b></td>
+    <td><b>message</b></td>
   </tr>
   <tr>
-    <td>identifier = <code>0x6363</code></td>
-    <td>message length = <code>0x0010</code></td>
+    <td><code>0x3e</code></td>
+    <td><code>0xffffffff...</code></td>
   </tr>
-  <tr>
-    <td colspan="3"><code>0xffffffffffffffff</code></td>
-  </tr>
-</table>
+</table
 
 When the end request is received, the full message is printed to the screen.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ An "end" request is sent in order for the receiver to know when a message is com
     <td><code>0x3e</code></td>
     <td><code>0xffffffff...</code></td>
   </tr>
-</table
+</table>
 
 When the end request is received, the full message is printed to the screen.
 

--- a/client.js
+++ b/client.js
@@ -25,9 +25,9 @@
 
     function send(msg) {
       var payloads = msg.match(/.{1,31}/g),
+          packets = [],
           payload,
-          length,
-          packets;
+          length;
 
       for(var i = 0; i < payloads.length; i++) {
         payload = payloads[i];

--- a/client.js
+++ b/client.js
@@ -36,6 +36,8 @@
 
         buffer = packet(payload);
         socket.send(buffer, 0, buffer.length, address, sent);
+
+        sleep(100);
       }
 
       buffer = packet('1f');
@@ -59,6 +61,13 @@
       raw.writeChecksum(buffer, 2, raw.createChecksum(buffer));
 
       return buffer;
+    }
+
+    function sleep(milliseconds) {
+      var start = new Date().getTime();
+      for(var i = 0; i < 1e7; i++)
+        if((new Date().getTime() - start) > milliseconds)
+          break;
     }
 
     function sent(error) {

--- a/client.js
+++ b/client.js
@@ -44,8 +44,7 @@
           return;
 
         var packet = packets.shift();
-
-        socket.send(packet, 0, packet.length, address, function(error, bytes) {
+        socket.send(packet, 0, packet.length, address, function(error) {
           if(error)
             throw error;
 
@@ -73,11 +72,6 @@
       raw.writeChecksum(buffer, 2, raw.createChecksum(buffer));
 
       return buffer;
-    }
-
-    function sent(error) {
-      if(error)
-        throw error;
     }
   };
 }());

--- a/client.js
+++ b/client.js
@@ -1,4 +1,6 @@
 (function() {
+  'use strict';
+
   module.exports = function(address, key) {
     if(!address) {
       console.log('Error: no IP address provided.');
@@ -12,28 +14,56 @@
       return;
     }
 
-    var exec = require('exec-sync'),
-        crypto = require('./encryption.js');
-
-    var id = 0x6363; // 'cc'
+    var raw = require('raw-socket'),
+        crypto = require('./encryption.js'),
+        socket = raw.createSocket({
+          protocol: raw.Protocol.ICMP
+        });
 
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', send);
 
     function send(msg) {
-      var payloads = msg.match(/.{1,8}/g),
-          payload;
+      var payloads = msg.match(/.{1,31}/g),
+          payload,
+          length,
+          buffer;
 
       for(var i = 0; i < payloads.length; i++) {
         payload = payloads[i];
-        payload = id.toString(16) +
-                  ('0000' + (payload.length * 2).toString(16)).substr(-4) +
-                  crypto.encrypt(payload, key);
+        length = ('00' + (payload.length * 2).toString(16)).substr(-2);
+        payload = length + crypto.encrypt(payload, key);
 
-        exec('ping -s 48 -c 1 -p ' + payload + ' ' + address);
+        buffer = packet(payload);
+        socket.send(buffer, 0, buffer.length, address, sent);
       }
 
-      exec('ping -s 48 -c 1 -p 63630010ffffffffffffffff ' + address); // end ping
+      buffer = packet('1f');
+      socket.send(buffer, 0, buffer.length, address, sent);
+    }
+
+    function packet(message) {
+      while(message.length < 64)
+        message += 'f';
+
+      var buffer = new Buffer(40);
+      buffer[0] = 0x08; // type
+      buffer[1] = 0x00; // code
+      buffer[2] = 0x00; // checksum placeholder
+      buffer[3] = 0x00; // checksum placeholder
+      buffer[4] = 0x00; // identifier
+      buffer[5] = 0x01; // identifier
+      buffer[6] = 0x0a; // seqnum
+      buffer[7] = 0x09; // seqnum
+      buffer.write(message, 8, 'hex');
+      raw.writeChecksum(buffer, 2, raw.createChecksum(buffer));
+
+      return buffer;
+    }
+
+    function sent(error) {
+      if(error)
+        throw error;
     }
   };
 }());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cryptochat",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "encrypted P2P chat over ICMP",
   "bin": {
     "cryptochat": "./cryptochat.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cryptochat",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "encrypted P2P chat over ICMP",
   "bin": {
     "cryptochat": "./cryptochat.js"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "cryptochat": "./cryptochat.js"
   },
   "dependencies": {
-    "exec-sync": "^0.1.6",
     "raw-socket": "^1.3.2",
     "terminal-colors": "^0.1.3"
   },

--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@
       // convert buffer to hex string
       buffer = buffer.toString('hex', 20, buffer.length);
       type = parseInt(buffer.substring(0, 2), 16);
-      length = parseInt(buffer.substring(16, 18), 16) * 2;
+      length = parseInt(buffer.substring(16, 18), 16);
 
       // get message
       offset = 18;

--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@
       // convert buffer to hex string
       buffer = buffer.toString('hex', 20, buffer.length);
       type = parseInt(buffer.substring(0, 2), 16);
-      length = parseInt(buffer.substring(16, 18), 16);
+      length = parseInt(buffer.substring(16, 18), 16) * 2;
 
       // get message
       offset = 18;

--- a/server.js
+++ b/server.js
@@ -23,10 +23,10 @@
       // convert buffer to hex string
       buffer = buffer.toString('hex', 20, buffer.length);
       type = parseInt(buffer.substring(0, 2), 16);
-      length = parseInt(buffer.substring(8, 9), 16);
+      length = parseInt(buffer.substring(16, 18), 16);
 
       // get message
-      offset = 9;
+      offset = 18;
       hex = buffer.substring(offset, offset + length);
 
       if(DEBUG) {

--- a/server.js
+++ b/server.js
@@ -1,4 +1,6 @@
 (function() {
+  'use strict';
+
   module.exports = function(key) {
     require('terminal-colors');
 
@@ -10,7 +12,6 @@
         });
 
     var message = '',
-        id = 0x6363, // 'cc'
         count = 0,
         offset,
         type,
@@ -20,22 +21,12 @@
     socket.on('message', listen);
     function listen(buffer, source) {
       // convert buffer to hex string
-      buffer = buffer.toString('hex');
-
-      // find identifier in buffer or return
-      offset = buffer.indexOf(id.toString(16));
-      if(offset === -1)
-        return;
-
-      // get length of message (first 2 bytes after identifier)
-      offset += 4;
-      length = parseInt(buffer.substring(offset, offset + 4), 16);
-
-      // get type of message
-      type = parseInt(buffer.substring(40, 42), 16);
+      buffer = buffer.toString('hex', 20, buffer.length);
+      type = parseInt(buffer.substring(0, 2), 16);
+      length = parseInt(buffer.substring(8, 10), 16);
 
       // get message
-      offset += 4;
+      offset = 10;
       hex = buffer.substring(offset, offset + length);
 
       if(DEBUG) {
@@ -51,7 +42,7 @@
         return;
 
       // end ping
-      if(hex === 'ffffffffffffffff') {
+      if((hex.match(/f/g) || []).length === hex.length) {
         process.stdout.write(source.green + ' ');
         process.stdout.write('[' + count + ']: ');
         process.stdout.write(message.bold + '\n');

--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@
   module.exports = function(key) {
     require('terminal-colors');
 
-    var DEBUG = false;
+    var DEBUG = true;
     var raw = require('raw-socket'),
         crypto = require('./encryption.js'),
         socket = raw.createSocket({
@@ -42,7 +42,7 @@
         return;
 
       // end ping
-      if((hex.match(/f/g) || []).length === hex.length) {
+      if(hex === 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff') {
         process.stdout.write(source.green + ' ');
         process.stdout.write('[' + count + ']: ');
         process.stdout.write(message.bold + '\n');

--- a/server.js
+++ b/server.js
@@ -23,10 +23,10 @@
       // convert buffer to hex string
       buffer = buffer.toString('hex', 20, buffer.length);
       type = parseInt(buffer.substring(0, 2), 16);
-      length = parseInt(buffer.substring(8, 10), 16);
+      length = parseInt(buffer.substring(8, 9), 16);
 
       // get message
-      offset = 10;
+      offset = 9;
       hex = buffer.substring(offset, offset + length);
 
       if(DEBUG) {


### PR DESCRIPTION
`0.5.2` to `1.0.0`

Removes the `exec-sync` dependency by using raw-socket to send ICMP requests. Improves performance by expanding the payload size to 32 bytes. Introduces minor bugfixes and improvements.
